### PR TITLE
New enhancements for consistent screenshots

### DIFF
--- a/HookCatcher/HookCatcher/management/commands/functions/diffs_from_pr.py
+++ b/HookCatcher/HookCatcher/management/commands/functions/diffs_from_pr.py
@@ -186,6 +186,8 @@ def redis_entrypoint(build_id, old_build_id=None, base_host=None, head_host=None
     LOGGER.info('Generating screenshots of states...')
     # Manual command line prompt to add the name of the HEAD branch host
     if base_host is None:
+        # NOTE NEED AT LEAST 2 WORKERS RUNNING FOR THIS TO WORK
+        # NOTE THE WORKER MAY HAVE LOGGING THAT FILLS IN THE INPUT
         base_host = raw_input("Provide the host for the BASE branch now: ")
     # update the urls for all BASE states to be the host domain of BASE branch
     for base_state in base_states_list:
@@ -218,6 +220,8 @@ def redis_entrypoint(build_id, old_build_id=None, base_host=None, head_host=None
 
     # Manual command line prompt to add the name of the HEAD branch host
     if head_host is None:
+        # NOTE NEED AT LEAST 2 WORKERS RUNNING FOR THIS TO WORK
+        # NOTE THE WORKER MAY HAVE LOGGING THAT FILLS IN THE INPUT
         head_host = raw_input("Provide the host for the HEAD branch now: ")
     # update the urls for all HEAD states to be the host domain of HEAD branch
     for head_state in head_states_list:

--- a/HookCatcher/HookCatcherProj/settings.py
+++ b/HookCatcher/HookCatcherProj/settings.py
@@ -117,13 +117,13 @@ MEDIA_URL = '/media/'
 
 
 # Leverage object file storage in s3 bucket
-# DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 # STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
-# AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID') or 'mingdaidev'
-# AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY') or 'mingdaidev'
-# AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME') or 'ming'
-# AWS_S3_ENDPOINT_URL = os.getenv('AWS_S3_ENDPOINT_URL') or 'http://minio'
+AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID') or 'mingdaidev'
+AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY') or 'mingdaidev'
+AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME') or 'ming'
+AWS_S3_ENDPOINT_URL = os.getenv('AWS_S3_ENDPOINT_URL') or 'http://minio'
 
 # Using Loggers instead of print statements for console output!
 LOGGING = {

--- a/chart/hookcatcher/templates/deployment.yaml
+++ b/chart/hookcatcher/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
+          resources:
+            requests:
+              cpu: 1
           env:
             - name: POSTGRES_PORT
               value: "{{ .Values.postgresqlservice.port }}"

--- a/chart/hookcatcher/templates/rqworker-deployment.yaml
+++ b/chart/hookcatcher/templates/rqworker-deployment.yaml
@@ -19,6 +19,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: {{ .Values.service.internalPort }}
+          resources:
+            requests:
+              cpu: 1
           command: ["make", "rqworkers"]
           env:
             - name: POSTGRES_PORT

--- a/chart/hookcatcher/values.yaml
+++ b/chart/hookcatcher/values.yaml
@@ -6,7 +6,7 @@ image:
   registry: docker.io
   org: learningequality
   name: health-inspector
-  tag: 2018-03-26
+  tag:
   pullPolicy: IfNotPresent
 service:
   name: python
@@ -33,3 +33,10 @@ postgresql:
 
 # basedomain
 basedomain: "learningequality.org"
+
+# AWS bucket
+s3:
+  AWS_ACCESS_KEY_ID: "GOOGJIOBV5P6ZX4ZWWCT"
+  AWS_SECRET_ACCESS_KEY: "qgC+EED28tVf3/Z+9R7kQVpDaUgbAtr4bALwqusB"
+  AWS_STORAGE_BUCKET_NAME: "health-inspector"
+  AWS_S3_ENDPOINT_URL: "https://storage.googleapis.com"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,1 @@
+TAG=$(date +%yy-%mm-%dd-%HH-%ss); echo $TAG; docker build . -t learningequality/health-inspector:$TAG; docker push learningequality/health-inspector:$TAG; helm upgrade --install health-inspector-deploy chart/hookcatcher --set image.tag=$TAG

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "chrome-launcher": "^0.4.0",
     "chrome-remote-interface": "^0.24.5",
     "minimist": "^1.2.0",
-    "puppeteer": "^0.13.0"
+    "puppeteer": "^1.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
 chrome-launcher@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.4.0.tgz#805e4a90d3d16c93655216aeba1fe880922ecc1f"
@@ -61,10 +65,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+concat-stream@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -95,13 +100,13 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-extract-zip@^1.6.5:
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+extract-zip@^1.6.6:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.7.tgz#a840b4b8af6403264c8db57f4f1a74333ef81fe9"
   dependencies:
-    concat-stream "1.6.0"
+    concat-stream "1.6.2"
     debug "2.6.9"
-    mkdirp "0.5.0"
+    mkdirp "0.5.1"
     yauzl "2.4.1"
 
 fd-slicer@~1.0.1:
@@ -125,7 +130,7 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-https-proxy-agent@^2.1.0:
+https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
@@ -153,9 +158,9 @@ lighthouse-logger@^1.0.0:
   dependencies:
     debug "^2.6.8"
 
-mime@^1.3.4:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+mime@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -170,12 +175,6 @@ minimist@0.0.8:
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@0.5.1:
   version "0.5.1"
@@ -213,18 +212,18 @@ proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
-puppeteer@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
+puppeteer@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.5.0.tgz#e35db3f3ba3d41013feb65be02bdaa727ec7b8ec"
   dependencies:
-    debug "^2.6.8"
-    extract-zip "^1.6.5"
-    https-proxy-agent "^2.1.0"
-    mime "^1.3.4"
+    debug "^3.1.0"
+    extract-zip "^1.6.6"
+    https-proxy-agent "^2.2.1"
+    mime "^2.0.3"
     progress "^2.0.0"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^3.0.0"
+    ws "^5.1.1"
 
 readable-stream@^2.2.2:
   version "2.3.6"
@@ -276,13 +275,11 @@ ws@2.0.x:
   dependencies:
     ultron "~1.1.0"
 
-ws@^3.0.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+ws@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e"
   dependencies:
     async-limiter "~1.0.0"
-    safe-buffer "~5.1.0"
-    ultron "~1.1.0"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
Cleaned up puppeteer to be more reliable. The bulk of the bottleneck is now on one line of waiting for page to fully load (line 74)

Cleaned up auto_screenshot command output puppeteer error logs and also make sure there is never a  Image File = None in the database. 

Changed deployment configurations to demand more CPU 

added a Bash script that does all the deployment commands all together. Docker build, Docker push, Helm upgrade
